### PR TITLE
master.cfg: Specify branch for gnulib git repository

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -135,6 +135,7 @@ OctaveStable.addSteps([
   steps.Git(
     name = "clone gnulib repository",
     repourl = GNULIB_GIT_REPO_URL,
+    branch = "master",
     mode = "full",
     method = "fresh",
     haltOnFailure = True,


### PR DESCRIPTION
The octave-stable builder seems to have problems updating the gnulib repository. The log shows that it tries to fetch from a "stable" branch (which doesn't exist in the upstream repository).
Maybe specifying the branch explicitly will help with this build step.
Side note: Why is this build step even necessary? Won't the bootstrap script in Octave's hg repository do that automatically?

I'm still learning how to interact with github. Please, let me know if this is not the way to propose changes.