### PR TITLE
Update master.cfg: Use ccache if available on worker

### DIFF
--- a/master/defaults/master.cfg
+++ b/master/defaults/master.cfg
@@ -399,6 +399,7 @@ OctaveMxeStableW32.addSteps([
     name = "configure",
     command = [
       "./configure",
+      "--enable-ccache",
       "--disable-system-octave",
       "--enable-devel-tools",
       "--enable-binary-packages",
@@ -419,6 +420,7 @@ OctaveMxeStableW64.addSteps([
     name = "configure",
     command = [
       "./configure",
+      "--enable-ccache",
       "--disable-system-octave",
       "--enable-devel-tools",
       "--enable-binary-packages",
@@ -438,6 +440,7 @@ OctaveMxeStableW64_64.addSteps([
     name = "configure",
     command = [
       "./configure",
+      "--enable-ccache",
       "--disable-system-octave",
       "--enable-devel-tools",
       "--enable-binary-packages",


### PR DESCRIPTION
Add "--enable-ccache" to the configure flags of the MXE Octave builders.