### PR TITLE
master/defaults/master.cfg

### DIFF
--- a/master/defaults/master.cfg
+++ b/master/defaults/master.cfg
@@ -15,6 +15,7 @@ OCTAVE_BRANCH = "stable"
 # URL of the mxe-octave Mercurial (hg) repository to build from.
 
 MXE_OCTAVE_HG_REPO_URL = "https://hg.octave.org/mxe-octave"
+MXE_OCTAVE_BRANCHES = ["default", "release"]
 
 # URL of the Gnulib git repository to build from.
 
@@ -92,10 +93,16 @@ c['protocols'] = {
 
 c['change_source'] = [
   changes.HgPoller(
-    project = "octave",
+    project = "octave repo",
     branches = [OCTAVE_BRANCH],
     repourl = OCTAVE_HG_REPO_URL,
     workdir = "/buildbot/data/octave-hg-repo"
+  ),
+  hanges.HgPoller(
+    project = "mxe octave repo",
+    branches = MXE_OCTAVE_BRANCHES,
+    repourl = MXE_OCTAVE_HG_REPO_URL,
+    workdir = "/buildbot/data/mxe-octave-hg-repo"
   )
 ]
 
@@ -115,7 +122,7 @@ c['schedulers'] = [
   ),
   schedulers.Nightly(
     name = "daily octave",
-    change_filter = util.ChangeFilter(project = "octave"),
+    change_filter = util.ChangeFilter(project = ["octave repo", "mxe octave repo"]),
     onlyIfChanged = True,
     builderNames = ["octave"],
     hour = 0


### PR DESCRIPTION
With this change the Nightly scheduler reacts on both
1. Changes on the Octave "stable" branch
2. Changes on the MXE-Octave "default" or "release" branch.  For the sake of simplicity just build all again once per day if anything has changed.