### PR TITLE
check.yaml: Update to pat-s/always-upload-cache@v3.

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -58,9 +58,9 @@ jobs:
 
       - name: setup cache
         id: setup-cache
-        # uses: actions/cache@v2
+        # uses: actions/cache@v3
         # The original action doesn't upload on error. Use this fork instead.
-        uses: pat-s/always-upload-cache@v2
+        uses: pat-s/always-upload-cache@v3
         with:
           path: oldid/${{ matrix.target }}
           key: oldid:${{ matrix.target }}:${{ steps.cache_timestamp.outputs.timestamp }}:${{ github.sha }}


### PR DESCRIPTION
Actions requiring Node.js 12 are deprecated.
See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/