### PR TITLE
check.yaml: Revert to "official" cache action.

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -58,9 +58,7 @@ jobs:
 
       - name: setup cache
         id: setup-cache
-        # uses: actions/cache@v3
-        # The original action doesn't upload on error. Use this fork instead.
-        uses: pat-s/always-upload-cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: oldid/${{ matrix.target }}
           key: oldid:${{ matrix.target }}:${{ steps.cache_timestamp.outputs.timestamp }}:${{ github.sha }}
@@ -150,6 +148,13 @@ jobs:
           BUILDID: ${{ steps.check-id.outputs.buildid }}
           TARGET: ${{ matrix.target }}
         run: echo $BUILDID > oldid/${TARGET}/id
+
+      - name: save cache with build id
+        if: steps.check-id.outputs.buildid != steps.check-id.outputs.oldbuildid
+        uses: actions/cache/save@v3
+        with:
+          path: oldid/${{ matrix.target }}
+          key: oldid:${{ matrix.target }}:${{ steps.cache_timestamp.outputs.timestamp }}:${{ github.sha }}
 
       - name: test packages
         if: steps.check-id.outputs.buildid != steps.check-id.outputs.oldbuildid


### PR DESCRIPTION
Use the action that is maintained by GitHub now that it allows saving the cache on error.