### PR TITLE
check.yaml: Use system OpenGL drivers on 32-bit.

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -107,6 +107,11 @@ jobs:
           ./post-install.bat
           echo "Use OpenBLAS"
           cp ./${MY_MINGW_PREFIX}/bin/libopenblas.dll ./${MY_MINGW_PREFIX}/bin/libblas.dll
+          # use system OpenGL drivers for 32-bit to avoid crash on printing with llvmpipe
+          if [ x${{ matrix.target }} = xw32 ]; then \
+            echo "Use system OpenGL drivers"
+            mv -f ./${MY_MINGW_PREFIX}/bin/opengl32.dll ./${MY_MINGW_PREFIX}/bin/opengl32.bak
+          fi
 
       - name: show hg ids
         if: steps.check-id.outputs.buildid != steps.check-id.outputs.oldbuildid


### PR DESCRIPTION
The opengl32.dll from mesa3d (llvmpipe) that is included in Octave for Windows leads to frequent crashes when trying to print (e.g., to a file or pipe). Use the OpenGL drivers installed on the system instead (even if they lead to test failures on the headless runners).