### PR TITLE
check.yaml: Schedule check at a later time of day.

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,8 +4,8 @@ on:
   # push:
   workflow_dispatch:
   schedule:
-    # Run job every day at 16:30 UTC
-    - cron: '30 16 * * *'
+    # Run job every day at 22:30 UTC
+    - cron: '30 22 * * *'
 
 jobs:
   check:


### PR DESCRIPTION
The buildbot worker on jwe's machine takes longer to build all variants than the previously used machine. Schedule the check at a later time of day to give more time for all variants to complete building and uploading.