### PR TITLE
check.yaml: React on error code returned by octave-launch.exe

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -226,7 +226,9 @@ jobs:
           do
             printf "   \033[0;32m==>\033[0m Testing package \033[0;32m${pkg}\033[0m\n"
             echo "::group::Test package $pkg"
-            ./octave-launch.exe --no-init-file --silent --no-history --eval "pkg('test','$pkg')" | tee ./test-$pkg.log
+            ( ./octave-launch.exe --no-init-file --silent --no-history --eval "pkg('test','$pkg')" \
+              || echo "::error::Octave terminated with error code $? during tests for package $pkg" ) \
+              | tee ./test-$pkg.log
             echo "::endgroup::"
             echo "::group::Display log for package $pkg"
             cat ./fntests.log


### PR DESCRIPTION
`octave-launch.exe` now returns the exit code from the Octave process.
See: https://hg.octave.org/mxe-octave/rev/392c5255d044

Don't terminate testing the installed Octave packages on an error. But display a message and continue with the remaining packages.
