### PR TITLE
Include tmp-* folders in log file archive.

### DIFF
--- a/master/defaults/master.cfg
+++ b/master/defaults/master.cfg
@@ -350,7 +350,7 @@ def mxe_common_steps_post(mxe_branch_name, suffix):
     ),
     steps.ShellCommand(
       name = "compress log",
-      command = ["zip", "-r", util.Property('MXE_LOG_FILE'), "log"],
+      command = ["zip", "-r", util.Property('MXE_LOG_FILE'), "log", "tmp-*"],
       timeout = 3600,
       haltOnFailure = False,
       workdir = "build"


### PR DESCRIPTION
This change includes the content of the folder of unsuccessful build attempts (i.e., the `tmp-*` folder(s)) in the archive with the log files.
That might help to debug build issues if the content of the log file alone isn't helpful enough.
