### PR TITLE
GitHub-CI: No longer check the 32-bit Windows package

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [w64-default, w64, w64-64, w32]
+        target: [w64-default, w64, w64-64]
         include:
           - target: w64-default
             file-suffix: default-w64
@@ -35,10 +35,6 @@ jobs:
             file-suffix: release-w64-64
             folder-suffix: w64-64
             mingw-prefix: mingw64
-          - target: w32
-            file-suffix: release-w32
-            folder-suffix: w32
-            mingw-prefix: mingw32
 
     env:
       MSYSTEM: MSYS
@@ -107,11 +103,6 @@ jobs:
           ./post-install.bat
           echo "Use OpenBLAS"
           cp ./${MY_MINGW_PREFIX}/bin/libopenblas.dll ./${MY_MINGW_PREFIX}/bin/libblas.dll
-          # use system OpenGL drivers for 32-bit to avoid crash on printing with llvmpipe
-          if [ x${{ matrix.target }} = xw32 ]; then \
-            echo "Use system OpenGL drivers"
-            mv -f ./${MY_MINGW_PREFIX}/bin/opengl32.dll ./${MY_MINGW_PREFIX}/bin/opengl32.bak
-          fi
 
       - name: show hg ids
         if: steps.check-id.outputs.buildid != steps.check-id.outputs.oldbuildid


### PR DESCRIPTION
Octave for Windows 32-bit is no longer supported. The Octave project no longer distributes updated binaries for that target. (And the checks are already failing since some time.)
So, just stop testing them.