### PR TITLE
Skip building MXE Octave for Windows 32-bit

### DIFF
--- a/master/defaults/master.cfg
+++ b/master/defaults/master.cfg
@@ -117,7 +117,6 @@ c['schedulers'] = [
     name = "force",
     builderNames = [
       "octave",
-      "octave-mxe-w32",
       "octave-mxe-w64",
       "octave-mxe-w64-64",
       "octave-mxe-default-w64"
@@ -133,7 +132,6 @@ c['schedulers'] = [
   schedulers.Triggerable(
     name = "trigger",
     builderNames = [
-      "octave-mxe-w32",
       "octave-mxe-w64",
       "octave-mxe-w64-64",
       "octave-mxe-default-w64"
@@ -422,27 +420,6 @@ def mxe_common_steps_post(mxe_branch_name, suffix):
   ]
 
 
-OctaveMxeReleaseW32 = util.BuildFactory()
-OctaveMxeReleaseW32.addSteps(mxe_common_steps_pre(MXE_OCTAVE_BRANCH_RELEASE))
-OctaveMxeReleaseW32.addSteps([
-  steps.ShellCommand(
-    name = "configure",
-    command = [
-      "./configure",
-      "--with-ccache",
-      "--disable-system-octave",
-      "--enable-devel-tools",
-      "--enable-binary-packages",
-      "--enable-octave=" + OCTAVE_BRANCH,
-      "--with-pkg-dir=../../mxe-octave-pkg",
-      "--disable-windows-64"
-    ],
-    haltOnFailure = True
-  )
-])
-OctaveMxeReleaseW32.addSteps(mxe_common_steps_post(MXE_OCTAVE_BRANCH_RELEASE, "w32"))
-
-
 OctaveMxeReleaseW64 = util.BuildFactory()
 OctaveMxeReleaseW64.addSteps(mxe_common_steps_pre(MXE_OCTAVE_BRANCH_RELEASE))
 OctaveMxeReleaseW64.addSteps([
@@ -509,11 +486,6 @@ c['builders'] = [
     name = "octave",
     workernames = my_workers,
     factory = OctaveStable
-  ),
-  util.BuilderConfig(
-    name = "octave-mxe-w32",
-    workernames = my_workers,
-    factory = OctaveMxeReleaseW32
   ),
   util.BuilderConfig(
     name = "octave-mxe-w64",


### PR DESCRIPTION
Octave for Windows 32-bit is no longer supported. The Octave project no longer distributes updated binaries for that target. (And the checks are already failing since some time.)
So, stop building them in CI.

This is a companion PR to #25 (and should be merged after the other PR).
