### PR TITLE
Update GitHub actions to newer versions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,29 +16,29 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ${{ matrix.type }}/Dockerfile

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: setup cache
         id: setup-cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: oldid/${{ matrix.target }}
           key: oldid:${{ matrix.target }}:${{ steps.cache_timestamp.outputs.timestamp }}:${{ github.sha }}
@@ -147,7 +147,7 @@ jobs:
 
       - name: save cache with build id
         if: steps.check-id.outputs.buildid != steps.check-id.outputs.oldbuildid
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: oldid/${{ matrix.target }}
           key: oldid:${{ matrix.target }}:${{ steps.cache_timestamp.outputs.timestamp }}:${{ github.sha }}


### PR DESCRIPTION
.github/workflows/build.yaml, check.yaml: GitHub-hosted runners are transitioning from Node.js 16 to Node.js 20. Update to the latest versions of actions to prepare for that change.
See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/