### PR TITLE
GitHub-CI: Package "tisean" is no longer built by MXE Octave.

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -209,7 +209,6 @@ jobs:
                 "struct"
                 "symbolic"
                 "tablicious"
-                "tisean"
                 "tsa"
                 "video"
                 "windows"


### PR DESCRIPTION
See: https://hg.octave.org/mxe-octave/rev/5caa20111eb1