### PR TITLE
GitHub-CI: Add image-acquisition to list of Octave packages

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -179,6 +179,7 @@ jobs:
                 "generate_html"
                 "geometry"
                 "gsl"
+                "image-acquisition"
                 "image"
                 "instrument-control"
                 "interval"


### PR DESCRIPTION
The image-acquisition package has been added to MXE Octave: https://hg.octave.org/mxe-octave/rev/42e2f4163413

Run its tests as part of the CI.