### PR TITLE
GitHub-CI: Add parallel to list of Octave packages

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -198,6 +198,7 @@ jobs:
                 "octproj"
                 "optim"
                 "optiminterp"
+                "parallel"
                 "quaternion"
                 "queueing"
                 "signal"


### PR DESCRIPTION
The parallel package has been added to MXE Octave: https://hg.octave.org/mxe-octave/rev/e3c37060acde

Run its tests as part of the CI.