### PR TITLE
GitHub-CI: Add fl-core to list of Octave packages

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -173,6 +173,7 @@ jobs:
                 "dataframe"
                 "dicom"
                 "financial"
+                "fl-core"
                 "fuzzy-logic-toolkit"
                 "ga"
                 "general"


### PR DESCRIPTION
The fl-core package has been re-enabled in MXE Octave: https://hg.octave.org/mxe-octave/rev/b009ee00e657

Run its tests as part of the CI.