### PR TITLE
Build packages in parallel.

### DIFF
--- a/master/defaults/master.cfg
+++ b/master/defaults/master.cfg
@@ -334,11 +334,20 @@ def mxe_common_steps_pre(mxe_branch_name):
 def mxe_common_steps_post(mxe_branch_name, suffix):
   return [
     steps.ShellCommand(
-      name = "make",
-      command = ["make", "JOBS=8", "all", "7z-dist", "zip-dist", "nsis-installer"],
+      name = "build Octave",
+      command = ["make", "JOBS=8"],
       timeout = 10800,
       haltOnFailure = False,
       workdir = "build"
+    ),
+    steps.ShellCommand(
+      name = "build remaining tools and packages",
+      command = ["make", "-j4", "JOBS=2", "all", "7z-dist", "zip-dist", "nsis-installer"],
+      timeout = 10800,
+      haltOnFailure = False,
+      workdir = "build",
+      doStepIf=lambda s: s.build.results == SUCCESS,
+      hideStepIf=lambda results, s: results == SKIPPED
     ),
     steps.SetProperty(
       name = "get MXE_LOG_FILE",


### PR DESCRIPTION
MXE Octave doesn't (currently?) support building with parallel `make` initially. However, once Octave has been (cross-)built, building multiple packages in parallel works fine. And it is more efficient to do so, e.g., because some parts of the build steps of any of the built packages (like running a configure script) cannot be parallelized. Building multiple packages in parallel allows using more CPU threads at the same time in these cases.

To allow that, invoke `make` twice: First, to build Octave (without parallel `make`). And then again if the previous invocation was successful, to build the remaining tools and packages (with four parallel `make` processes).

That should be the equivalent of running the following command locally: 
`make JOBS=8 && make -j4 JOBS=2 all 7z-dist zip-dist nsis-installer`

@siko1056: I don't know how to test these changes. Does this look reasonable to you?
