### PR TITLE
Attempt to fix errors about undefined names.

### DIFF
--- a/master/defaults/master.cfg
+++ b/master/defaults/master.cfg
@@ -346,8 +346,8 @@ def mxe_common_steps_post(mxe_branch_name, suffix):
       timeout = 10800,
       haltOnFailure = False,
       workdir = "build",
-      doStepIf=lambda s: s.build.results == SUCCESS,
-      hideStepIf=lambda results, s: results == SKIPPED
+      doStepIf=lambda s: s.build.results == buildbot.process.results.SUCCESS,
+      hideStepIf=lambda results, s: results == buildbot.process.results.SKIPPED
     ),
     steps.SetProperty(
       name = "get MXE_LOG_FILE",

--- a/master/defaults/master.cfg
+++ b/master/defaults/master.cfg
@@ -51,6 +51,7 @@ RSYNC_DATA_DIR = RSYNC_HOST + ":" + DATA_DIR
 
 from buildbot.plugins import *
 from buildbot.process.properties import Property
+from buildbot.process.results import SUCCESS, SKIPPED
 from app.octave_download_app import octavedownloadapp
 octavedownloadapp.config["DATA_DIR"] = DATA_DIR
 octavedownloadapp.config["DATA_URL"] = DATA_URL
@@ -346,8 +347,8 @@ def mxe_common_steps_post(mxe_branch_name, suffix):
       timeout = 10800,
       haltOnFailure = False,
       workdir = "build",
-      doStepIf=lambda s: s.build.results == buildbot.process.results.SUCCESS,
-      hideStepIf=lambda results, s: results == buildbot.process.results.SKIPPED
+      doStepIf=lambda s: s.build.results == SUCCESS,
+      hideStepIf=lambda results, s: results == SKIPPED
     ),
     steps.SetProperty(
       name = "get MXE_LOG_FILE",


### PR DESCRIPTION
The buildbots are failing after #35 with errors like the following:
* builtins.NameError: name 'SUCCESS' is not defined
* builtins.NameError: name 'SKIPPED' is not defined

That might be because these constants need to be fully qualified. 

Add the full namespace where these constants are used.

@siko1056: This is still untested. But maybe it helps to fix the changes from #35. Should we revert #35? Or attempt with this change?