### PR TITLE
GitHub-CI: Add coder to list of Octave packages

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -166,6 +166,7 @@ jobs:
           pkgs=("audio"
                 "biosig"
                 "cfitsio"
+                "coder"
                 "communications"
                 "control"
                 "data-smoothing"


### PR DESCRIPTION
The Octave coder package has been added to MXE Octave: 
https://hg.octave.org/mxe-octave/rev/b58703eb267e

The package currently does not have any built-in self-tests. At least, this change will allow to check whether the package successfully loads and unloads. (And maybe, there will be actual tests at some point in the future.)