### PR TITLE
Pull from Octave mirror on GitHub.

### DIFF
--- a/master/defaults/app/octave_download_app.html
+++ b/master/defaults/app/octave_download_app.html
@@ -76,7 +76,7 @@
     <summary>
       <b>Octave {{build.builds[0].properties.OCTAVE_VERSION[0]}}</b>
       &nbsp;&nbsp;
-      (hg id: <a target="_blank" href="{{config.repo_change_url}}/{{build.builds[0].properties.OCTAVE_HG_ID[0]}}">{{build.builds[0].properties.OCTAVE_HG_ID[0]}}</a>)
+      (hg id: <a target="_blank" href="{{config.repo_change_url}}/{{build.builds[0].properties.OCTAVE_GIT_REV[0]}}">{{build.builds[0].properties.OCTAVE_GIT_REV[0]}}</a>)
       &nbsp;&nbsp;
       {{build.date}}
     </summary>

--- a/master/defaults/app/octave_download_app.py
+++ b/master/defaults/app/octave_download_app.py
@@ -99,9 +99,9 @@ def main():
   # URL, where Octave builds are visible to the public.
   config["data_url"] = octavedownloadapp.config["DATA_URL"]
   # Repository from which Octave is built.
-  config["repo_url"] = octavedownloadapp.config["OCTAVE_HG_REPO_URL"]
+  config["repo_url"] = octavedownloadapp.config["OCTAVE_GIT_REPO_URL"]
   # URL-prefix to changes in the repository from which Octave is built.
-  config["repo_change_url"] = octavedownloadapp.config["OCTAVE_HG_REPO_CHANGE_URL"]
+  config["repo_change_url"] = octavedownloadapp.config["OCTAVE_GIT_REPO_CHANGE_URL"]
 
   buildbot_data = getBuildBotData()
 

--- a/master/defaults/master.cfg
+++ b/master/defaults/master.cfg
@@ -8,8 +8,8 @@
 # URL of the Octave Mercurial (hg) repository to build from
 # and to individual revision (changes).  The ID is added automatically.
 
-OCTAVE_HG_REPO_URL = "https://hg.savannah.gnu.org/hgweb/octave"
-OCTAVE_HG_REPO_CHANGE_URL = OCTAVE_HG_REPO_URL + "/rev"
+OCTAVE_GIT_REPO_URL = "https://github.com/gnu-octave/octave.git"
+OCTAVE_GIT_REPO_CHANGE_URL = OCTAVE_GIT_REPO_URL + "/commit"
 OCTAVE_BRANCH = "stable"
 
 # URL of the mxe-octave Mercurial (hg) repository to build from.
@@ -55,8 +55,8 @@ from buildbot.process.results import SUCCESS, SKIPPED
 from app.octave_download_app import octavedownloadapp
 octavedownloadapp.config["DATA_DIR"] = DATA_DIR
 octavedownloadapp.config["DATA_URL"] = DATA_URL
-octavedownloadapp.config["OCTAVE_HG_REPO_URL"] = OCTAVE_HG_REPO_URL
-octavedownloadapp.config["OCTAVE_HG_REPO_CHANGE_URL"] = OCTAVE_HG_REPO_CHANGE_URL
+octavedownloadapp.config["OCTAVE_GIT_REPO_URL"] = OCTAVE_GIT_REPO_URL
+octavedownloadapp.config["OCTAVE_GIT_REPO_CHANGE_URL"] = OCTAVE_GIT_REPO_CHANGE_URL
 
 # This is a sample buildmaster config file.  It must be installed as
 # 'master.cfg' in your buildmaster's base directory.
@@ -95,11 +95,11 @@ c['protocols'] = {
 # about source code changes.
 
 c['change_source'] = [
-  changes.HgPoller(
+  changes.GitPoller(
     project = "octave repo",
     branches = [OCTAVE_BRANCH],
-    repourl = OCTAVE_HG_REPO_URL,
-    workdir = "/buildbot/data/octave-hg-repo"
+    repourl = OCTAVE_GIT_REPO_URL,
+    workdir = "/buildbot/data/octave-git-repo"
   ),
   changes.HgPoller(
     project = "mxe octave repo",
@@ -175,14 +175,13 @@ OctaveStable.addSteps([
     haltOnFailure = True,
     workdir = "gnulib"
   ),
-  steps.Mercurial(
+  steps.Git(
     name = "clone Octave repository",
-    repourl = OCTAVE_HG_REPO_URL,
+    repourl = OCTAVE_GIT_REPO_URL,
+    branch = OCTAVE_BRANCH,
+    alwaysUseLatest = True,
     mode = "full",
     method = "fresh",
-    branchType = "inrepo",
-    defaultBranch = OCTAVE_BRANCH,
-    alwaysUseLatest = True,
     haltOnFailure = True,
     workdir = "src"
   ),
@@ -194,9 +193,9 @@ OctaveStable.addSteps([
     workdir = "src"
   ),
   steps.SetPropertyFromCommand(
-    name = "get OCTAVE_HG_ID",
-    command = "hg identify --id",
-    property = "OCTAVE_HG_ID",
+    name = "get OCTAVE_GIT_REV",
+    command = "git rev-parse HEAD",
+    property = "OCTAVE_GIT_REV",
     haltOnFailure = True,
     workdir = "src"
   ),
@@ -280,7 +279,7 @@ OctaveStable.addSteps([
     schedulerNames = ["trigger"],
     set_properties = {
       "OCTAVE_BUILD_ID" : Property("OCTAVE_BUILD_ID"),
-      "OCTAVE_HG_ID"    : Property("OCTAVE_HG_ID"),
+      "OCTAVE_GIT_REV"    : Property("OCTAVE_GIT_REV"),
       "OCTAVE_VERSION"  : Property("OCTAVE_VERSION")
     }
   ),


### PR DESCRIPTION
The anonymous access over HTTPS to the Mercurial repository on Savannah is getting more and more unreliable. (That is possibly because crawlers for LLMs are hammering that server with a torrent of requests.)

Attempt to pull the repository from the mirror of the Octave repository on GitHub instead.
That way, we only rely on the synchronization from the Mercurial repository on Savannah to the GitHub mirror. But we don't rely on the Mercurial repository on Savannah to be available each time a build starts or the buildbot scheduler checks for updates.

The MXE Octave repository (on the Digital Ocean server) is still responsive most of the time. (Maybe, the crawlers didn't find it yet.) And we don't have a mirror for that (yet?). So, keep pulling the Mercurial repository for it.

These might make it slightly more inconvenient to match a nightly build with a Mercurial commit. But I'm hoping that GitHub can better deal with these crawlers and it will be more available.

I still don't know how to test anything buildbot related.

@siko1056: Do these changes look reasonable? Should we attempt that?